### PR TITLE
[IP-612] Chore/separate rename

### DIFF
--- a/lib/model_renamer/rename.rb
+++ b/lib/model_renamer/rename.rb
@@ -39,6 +39,9 @@ class Rename
   end
 
   def rename_in_files
+    all_filepaths.each do |filepath|
+      replace_all_variations_in_file filepath
+    end
   end
 
   private

--- a/lib/model_renamer/rename.rb
+++ b/lib/model_renamer/rename.rb
@@ -21,21 +21,17 @@ class Rename
   end
 
   def rename
-    replace_all_occurrences
+    rename_files_and_directories
+    rename_in_files
   end
 
   def generate_migrations
     MigrationGenerator.new(@variations_generator.underscore_variations).create_migration_file
   end
 
-  def rename_files
-    all_filepaths.each do |filepath|
-      rename_file filepath
-    end
-
-    all_filepaths.each do |filepath|
-      rename_directory filepath
-    end
+  def rename_files_and_directories
+    rename_files
+    rename_directories
   end
 
   def rename_in_files
@@ -45,17 +41,6 @@ class Rename
   end
 
   private
-
-  def replace_all_occurrences
-    all_filepaths.each do |filepath|
-      replace_all_variations_in_file filepath
-      rename_file filepath
-    end
-
-    all_filepaths.each do |filepath|
-      rename_directory filepath
-    end
-  end
 
   def variation_pairs
     @variation_pairs ||= @variations_generator.pairs_to_convert
@@ -91,17 +76,16 @@ class Rename
     end
   end
 
-  def rename_file filepath
-    variation_pairs.each do |old_name, new_name|
+  def rename_files
+    all_filepaths.product(variation_pairs).each do |filepath, (old_name, new_name)|
       next unless File.basename(filepath).include? old_name
       filename = File.basename(filepath)
       File.rename filepath, filepath.gsub(filename, filename.gsub(old_name, new_name))
-      break
     end
   end
 
-  def rename_directory filepath
-    variation_pairs.each do |old_name, new_name|
+  def rename_directories
+    all_filepaths.product(variation_pairs).each do |filepath, (old_name, new_name)|
       next unless File.file?(filepath) && File.dirname(filepath).include?(old_name)
       FileUtils.mv File.dirname(filepath), File.dirname(filepath).gsub(old_name, new_name)
     end

--- a/lib/model_renamer/rename.rb
+++ b/lib/model_renamer/rename.rb
@@ -28,6 +28,12 @@ class Rename
     MigrationGenerator.new(@variations_generator.underscore_variations).create_migration_file
   end
 
+  def rename_files
+  end
+
+  def replace_files_contents
+  end
+
   private
 
   def replace_all_occurrences

--- a/spec/model_renamer/rename_spec.rb
+++ b/spec/model_renamer/rename_spec.rb
@@ -290,5 +290,51 @@ describe Rename do
         expect(File.read('./account_manager/account.rb')).to eq(client_company_content)
       end
     end
+
+    describe '#rename_in_files' do
+      let(:client_company_content) do
+        <<~DOC
+          class ClientCompany
+          end
+        DOC
+      end
+      let(:client_company_manager_content) do
+        <<~DOC
+          class ClientCompanyManager::ClientCompany
+          end
+        DOC
+      end
+      let(:account_content) do
+        <<~DOC
+          class Account
+          end
+        DOC
+      end
+      let(:account_manager_content) do
+        <<~DOC
+          class AccountManager::Account
+          end
+        DOC
+      end
+
+      before do
+        FileUtils.mkdir_p './client_company_manager'
+
+        File.open('./client_company_manager/client_company.rb', 'w') { |f| f.write client_company_manager_content }
+        File.open('./client_company.rb', 'w') { |f| f.write client_company_content }
+
+        Rename.new('ClientCompany', 'Account').rename_in_files
+      end
+
+      it 'does not modify the directories or file names' do
+        expect(File.exist?('./client_company.rb')).to be true
+        expect(File.exist?('./client_company_manager/client_company.rb')).to be true
+      end
+
+      it 'renames inside the file' do
+        expect(File.read('./client_company.rb')).to eq account_content
+        expect(File.read('./client_company_manager/client_company.rb')).to eq account_manager_content
+      end
+    end
   end
 end

--- a/spec/model_renamer/rename_spec.rb
+++ b/spec/model_renamer/rename_spec.rb
@@ -4,35 +4,35 @@ describe Rename do
   end
 
   describe 'rename ClientCompany to Account' do
-    def client_company_model_content
+    let(:client_company_model_content) do
       <<~HEREDOC
         class ClientCompany
         end
       HEREDOC
     end
 
-    def client_company_controller_content
+    let(:client_company_controller_content) do
       <<~HEREDOC
         class ClientCompanyController < ApplicationController
         end
       HEREDOC
     end
 
-    def account_model_content
+    let(:account_model_content) do
       <<~HEREDOC
         class Account
         end
       HEREDOC
     end
 
-    def account_controller_content
+    let(:account_controller_content) do
       <<~HEREDOC
         class AccountController < ApplicationController
         end
       HEREDOC
     end
 
-    def client_company_manager_import_users_service_content
+    let(:client_company_manager_import_users_service_content) do
       <<~HEREDOC
         class ClientCompanyManager::ImportUsersService
           def initialize client_company
@@ -42,7 +42,7 @@ describe Rename do
       HEREDOC
     end
 
-    def account_manager_import_users_service_content
+    let(:account_manager_import_users_service_content) do
       <<~HEREDOC
         class AccountManager::ImportUsersService
           def initialize account
@@ -52,7 +52,7 @@ describe Rename do
       HEREDOC
     end
 
-    def client_company_user_model_content
+    let(:client_company_user_model_content) do
       <<~HEREDOC
         class ClientCompanyUser < ActiveRecord::Base
           belongs_to :client_company
@@ -61,7 +61,7 @@ describe Rename do
       HEREDOC
     end
 
-    def account_user_model_content
+    let(:account_user_model_content) do
       <<~HEREDOC
         class AccountUser < ActiveRecord::Base
           belongs_to :account
@@ -70,7 +70,7 @@ describe Rename do
       HEREDOC
     end
 
-    def client_company_service_js_content
+    let(:client_company_service_js_content) do
       <<~HEREDOC
         angular.module("vts").factory("ClientCompanyService", (DataCache, queryStringSerializer) => {
           return new (class ClientCompanyService extends DataCache {
@@ -102,7 +102,7 @@ describe Rename do
       HEREDOC
     end
 
-    def account_service_js_content
+    let(:account_service_js_content) do
       <<~HEREDOC
         angular.module("vts").factory("AccountService", (DataCache, queryStringSerializer) => {
           return new (class AccountService extends DataCache {
@@ -134,7 +134,7 @@ describe Rename do
       HEREDOC
     end
 
-    def client_company_manager_translation_yml_content
+    let(:client_company_manager_translation_yml_content) do
       <<~HEREDOC
         en-us:
           views:
@@ -145,7 +145,7 @@ describe Rename do
       HEREDOC
     end
 
-    def account_manager_translation_yml_content
+    let(:account_manager_translation_yml_content) do
       <<~HEREDOC
         en-us:
           views:
@@ -193,7 +193,7 @@ describe Rename do
   end
 
   describe 'options hash' do
-    def client_company_migration_content
+    let(:client_company_migration_content) do
       <<~HEREDOC
         class AddClientCompanyToDeals < ActiveRecord::Migration
           def change
@@ -203,7 +203,7 @@ describe Rename do
       HEREDOC
     end
 
-    def account_migration_content
+    let(:account_migration_content) do
       <<~HEREDOC
         class AddAccountToDeals < ActiveRecord::Migration
           def change

--- a/spec/model_renamer/rename_spec.rb
+++ b/spec/model_renamer/rename_spec.rb
@@ -271,7 +271,7 @@ describe Rename do
         File.open('./client_company_manager/client_company.rb', 'w') { |f| f.write client_company_content }
         File.open('./foo.rb', 'w') { |f| f.write foo_content }
 
-        Rename.new('ClientCompany', 'Account').rename_files
+        Rename.new('ClientCompany', 'Account').rename_files_and_directories
       end
 
       it 'renames the directories' do


### PR DESCRIPTION
Separate renaming files and directories from renaming content inside files.

Also fixes a bug where old_name directories were never removed because we were creating new directories. We solve this issue by first renaming all files and then renaming all directories.

@viewthespace/toolbox 